### PR TITLE
docs(readme): Revise running instructions for App Router + Docker stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,118 @@
-This repo was made with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) using the latest version of NextJS/TypeScript and connects using the v3 of the Content API from [`GhostCMS`](https://ghost.org/docs/content-api/javascript/).
+This repo was made with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) using the latest version of Next.js with the App Router (TypeScript) and connects to the [GhostCMS Content API](https://ghost.org/docs/content-api/javascript/) (v5.0).
 
-This serves as a starting template to fetch and retieve all posts and single posts as a Statically Generated Site. I might update this repo in the future to use other parts of the GhostCMS Content API, but this is just a proof of concept.
+It serves as a starting template to fetch and retrieve all posts and single posts as a Statically Generated Site using the App Router (`src/app/`). It might be updated in the future to use other parts of the GhostCMS Content API, but this is a proof of concept.
 
-## Getting Started
+## Prerequisites
 
-First, create your own .env file using the .env-example file and replace the values of your BLOG_URL and CONTENT_API_KEY with the values that you get from GhostCMS. If you currently don't have a Content API Key, you can create one by going to the GhostCMS Admin panel and adding a Custom Integration.
+- [Node.js](https://nodejs.org/) (v20+ recommended)
+- [pnpm](https://pnpm.io/) — the project's package manager (see `pnpm-lock.yaml`)
+- [Docker](https://www.docker.com/) and the Docker Compose plugin — only required if you want to run the full self-hosted stack (Ghost CMS + MySQL + Caddy reverse proxy + Next.js)
 
-Second, run the development server:
+## Configuration
+
+This project ships two configuration surfaces:
+
+1. **`.env`** — required by both the Next.js app (Ghost Content API key + blog URL) and the Docker Compose stack (domain, database, mail, storage, etc.).
+2. **`caddy/Caddyfile`** — only used by the Docker stack. A working example (`Caddyfile.example`) is provided for reference.
+
+Start by copying the example file and filling in your values:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
+cp .env-example .env
+```
+
+The minimum values you need to run the Next.js app against an existing Ghost instance are:
+
+| Variable          | Description                                                                 |
+| ----------------- | --------------------------------------------------------------------------- |
+| `CONTENT_API_KEY` | Content API key from GhostCMS Admin → Settings → Integrations → Custom Integration. |
+| `BLOG_URL`        | The base URL of your GhostCMS instance (e.g. `https://my-ghost.example.com`). |
+
+If you also intend to run the full Docker stack (recommended), fill in the remaining values in `.env` (database credentials, `DOMAIN`, SMTP, Cloudinary, etc.) following the inline comments. The database and `DOMAIN` values must be set before the first `docker compose up` and **must not** be changed after initialization.
+
+## Running the Full Stack (Recommended)
+
+The repository's `compose.yml` defines a complete self-hosted stack:
+
+- **`ghost`** — the GhostCMS server (with Cloudinary storage adapter)
+- **`db`** — a MySQL 8.4 database
+- **`app`** — this Next.js app running in dev mode (with Turbopack)
+- **`caddy`** — a Caddy reverse proxy that terminates TLS and routes traffic to the Next.js app and (optionally) Ghost Admin
+
+With `.env` populated, start the whole stack:
+
+```bash
+docker compose up --build
+```
+
+Once the containers are healthy:
+
+- The public site is served by Caddy at `https://<DOMAIN>` (uses Caddy's local CA for `localhost`/`*.localhost` domains).
+- Ghost Admin is available at `https://<ADMIN_DOMAIN>` if `ADMIN_DOMAIN` is set.
+
+### Optional Services
+
+Two optional profiles are available and can be enabled by setting the `COMPOSE_PROFILES` variable in your `.env`:
+
+```bash
+COMPOSE_PROFILES=analytics,activitypub
+```
+
+- **Analytics** — runs the `traffic-analytics` and Tinybird (`tinybird-login`, `tinybird-sync`, `tinybird-deploy`) containers. Run `docker compose run --rm tinybird-login get-tokens` first and paste the returned tokens into `.env`.
+- **ActivityPub** — runs the `activitypub` container and its `activitypub-migrate` migration job.
+
+Then start the stack with the desired profiles:
+
+```bash
+docker compose --profile analytics --profile activitypub up --build
+```
+
+## Running the Next.js App Locally (Without Docker)
+
+If you already have a Ghost instance running (either self-hosted or on [Ghost(Pro)](https://ghost.org/pricing/)), you can run just the Next.js app against it.
+
+Make sure `CONTENT_API_KEY` and `BLOG_URL` are set in your `.env`, then install dependencies and start the dev server (Turbopack is enabled by default):
+
+```bash
+pnpm install
 pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result. The page auto-updates as you edit files.
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+### Useful Scripts
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
+| Command           | Description                          |
+| ----------------- | ------------------------------------ |
+| `pnpm dev`        | Start the dev server with Turbopack. |
+| `pnpm build`      | Build the app for production.       |
+| `pnpm start`      | Start the production server.        |
+| `pnpm lint`       | Run ESLint.                          |
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+## Project Structure
 
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
+```
+.
+├─ compose.yml        Full self-hosted stack (Ghost + MySQL + Caddy + Next.js)
+├─ Dockerfile         Ghost image with the Cloudinary storage adapter baked in
+├─ caddy/             Caddy reverse proxy config + reusable snippets
+├─ src/
+│  ├─ app/            App Router: layout.tsx, page.tsx, and post/[slug]/ page
+│  ├─ helper/util.tsx GhostCMS Content API client and data-fetching helpers
+│  └─ styles/         Global + component CSS Modules
+└─ public/            Static assets (favicon, brand SVGs)
+```
+
+Start editing the home page in `src/app/page.tsx`. Single posts are served by the dynamic route at `src/app/post/[slug]/page.tsx`. Data fetching happens through the helpers in `src/helper/util.tsx`, and you can change the Ghost API version there (currently `v5.0`).
 
 ## Learn More
 
-To learn more about Next.js, take a look at the following resources:
+To learn more about the technologies used here:
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
+- [Next.js Documentation](https://nextjs.org/docs) — learn about Next.js features and the App Router.
+- [GhostCMS Content API](https://ghost.org/docs/content-api/javascript/) — the API this template pulls posts from.
+- [Docker Compose](https://docs.docker.com/compose/) — used for the full self-hosted stack.
 
 ## Deploy on Vercel
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+The Next.js app can be deployed independently on [Vercel](https://vercel.com/new) from the creators of Next.js. Be sure to set the `BLOG_URL` and `CONTENT_API_KEY` environment variables in your Vercel project settings. See the [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.


### PR DESCRIPTION
## Summary

Revises the README to reflect the current state of the project. The previous "Getting Started" section was outdated — it referenced the Pages Router (`pages/index.tsx`, `pages/api/hello.ts`), generic `npm`/`yarn`/`pnpm` commands, and Ghost Content API v3, none of which match the codebase today.

## What changed

- **Replaced "Getting Started"** with two clearly separated sections:
  - **Running the Full Stack (Recommended)** — documents the `docker compose up --build` workflow for the Ghost CMS + MySQL + Caddy reverse proxy + Next.js stack, including the optional `analytics` and `activitypub` profiles.
  - **Running the Next.js App Locally (Without Docker)** — documents `pnpm install` + `pnpm dev` (Turbopack) against an external/self-hosted Ghost instance, with a table of the available scripts (`dev`, `build`, `start`, `lint`).
- **Added a Prerequisites section** listing Node.js, pnpm, and Docker (Docker only required for the full stack).
- **Added a Configuration section** explaining the `.env` file with a table of the minimum required variables (`CONTENT_API_KEY`, `BLOG_URL`) and notes on the Docker-only variables.
- **Updated the intro and supporting sections** to match the App Router project: corrected the Ghost Content API version (v5.0), added a Project Structure section (`src/app/`, `src/helper/util.tsx`, `compose.yml`, `Dockerfile`, `caddy/`), and refreshed Learn More / Deploy on Vercel sections that drop the outdated Pages Router references.

## Why

The README still described the original `create-next-app` Pages Router template even though the project has since:
- Migrated to the App Router (`src/app/`)
- Added a full Docker Compose stack (`compose.yml`, `Dockerfile`, `caddy/`)
- Pinned pnpm as the only package manager
- Enabled Turbopack in the `dev` script
- Added optional Analytics (Tinybird) and ActivityPub profiles

## Checklist

- [x] Running instructions cover both the Docker Compose stack and local dev
- [x] No references to the removed Pages Router files remain
- [x] Commit follows the repo's conventional commit + emoji style
- [x] No code changes — documentation only

## Notes

- No PR template was found in the repo, so the description above follows a standard summary/what-changed/why structure.
- The lowercase `readme.md` referenced in the original task does not exist — the actual file is `README.md`, which is the only file touched by this PR.